### PR TITLE
add support for java.util.logging

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -9,6 +9,7 @@ Versions up to 0.4.X provide a [JUnit 4 `@Rule`](https://github.com/junit-team/j
 It currently supports
 * [log4j 2.x](https://logging.apache.org/log4j/2.x/): _assertj-logging-log4j_
 * [logback](http://logback.qos.ch/): _assertj-logging-logback_
+* [java.util.logging](https://docs.oracle.com/en/java/javase/17/core/java-logging-overview.html) _assertj-logging-jul_
 
 
 ## Contents
@@ -109,6 +110,9 @@ public class LoggingSourceTest {
 ### Supported Log Levels
 
 We consider _ERROR_, _WARNING_ and _INFO_ to be the test-worthy log levels.
+
+For java.util.logging this translates to _SEVERE_, _WARNING_ and _INFO_ levels.
+
 
 Thus, _assertj-logging_ provides assertions for these log levels.
 

--- a/assertj-logging-jul/src/main/java/de/neuland/assertj/logging/ExpectedLogging.java
+++ b/assertj-logging-jul/src/main/java/de/neuland/assertj/logging/ExpectedLogging.java
@@ -1,0 +1,46 @@
+package de.neuland.assertj.logging;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@inheritDoc}
+ */
+public class ExpectedLogging extends GenericExpectedLogging<JavaUtilLoggingLogEventCaptureAppender> {
+
+    private final Logger logger;
+
+    private ExpectedLogging( String loggingSource ) {
+        super( loggingSource );
+        logger = getCoreLogger();
+    }
+
+
+    public static ExpectedLogging forSource( Class<?> loggingSource ) {
+        return new ExpectedLogging( loggingSource.getCanonicalName() );
+    }
+
+
+    @Override
+    JavaUtilLoggingLogEventCaptureAppender addCaptureAppender() {
+        JavaUtilLoggingLogEventCaptureAppender appender = new JavaUtilLoggingLogEventCaptureAppender();
+        logger.addHandler( appender );
+        return appender;
+    }
+
+    @Override
+    void assertLoggerLevelIsAtLeastInfo() {
+        if ( logger.getLevel() == null || logger.getLevel().intValue() < Level.INFO.intValue() ) {
+            logger.setLevel( Level.INFO );
+        }
+    }
+
+    @Override
+    void removeCaptureAppender( JavaUtilLoggingLogEventCaptureAppender appender ) {
+        logger.removeHandler( appender );
+    }
+
+    private Logger getCoreLogger() {
+        return Logger.getLogger( loggingSource );
+    }
+}

--- a/assertj-logging-jul/src/main/java/de/neuland/assertj/logging/ExpectedLoggingAssertions.java
+++ b/assertj-logging-jul/src/main/java/de/neuland/assertj/logging/ExpectedLoggingAssertions.java
@@ -1,0 +1,7 @@
+package de.neuland.assertj.logging;
+
+public class ExpectedLoggingAssertions {
+    public static ExpectedLoggingAssert assertThat(ExpectedLogging actual) {
+        return new ExpectedLoggingAssert(actual);
+    }
+}

--- a/assertj-logging-jul/src/main/java/de/neuland/assertj/logging/JavaUtilLoggingLogEventCaptureAppender.java
+++ b/assertj-logging-jul/src/main/java/de/neuland/assertj/logging/JavaUtilLoggingLogEventCaptureAppender.java
@@ -1,0 +1,44 @@
+package de.neuland.assertj.logging;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+public class JavaUtilLoggingLogEventCaptureAppender extends Handler implements LogEventCaptureAppender {
+
+    private final List<LogEvent> logEvents = new ArrayList<>();
+    private static final String ACCEPTED_LEVELS = String.format( "%s, %s or %s", Level.INFO.getName(), Level.WARNING.getName(),
+                                                                 Level.SEVERE.getName() );
+
+    @Override
+    public List<LogEvent> getLogEvents() {
+        return logEvents;
+    }
+
+    @Override
+    public void publish( LogRecord logRecord ) {
+        LogLevel level;
+        Level logRecordLevel = logRecord.getLevel();
+        if ( logRecordLevel.equals( Level.INFO ) ) {
+            level = LogLevel.INFO;
+        } else if ( logRecordLevel.equals( Level.WARNING ) ) {
+            level = LogLevel.WARNING;
+        } else if ( logRecordLevel.equals( Level.SEVERE ) ) {
+            level = LogLevel.ERROR;
+        } else {
+            throw new IllegalStateException( "Unexpected value: " + logRecord.getLevel() + ", should be one of " + ACCEPTED_LEVELS );
+        }
+        logEvents.add( new LogEvent( level, logRecord.getMessage(), logRecord.getThrown() ) );
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void close() throws SecurityException {
+        logEvents.clear();
+    }
+}

--- a/assertj-logging-jul/src/test/java/de/neuland/assertj/logging/JavaUtilExpectedLoggingTest.java
+++ b/assertj-logging-jul/src/test/java/de/neuland/assertj/logging/JavaUtilExpectedLoggingTest.java
@@ -1,0 +1,45 @@
+package de.neuland.assertj.logging;
+
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import lombok.extern.java.Log;
+
+@Log
+public class JavaUtilExpectedLoggingTest extends GenericExpectedLoggingTest<ExpectedLogging> {
+
+    @RegisterExtension
+    private final ExpectedLogging logging = ExpectedLogging.forSource( JavaUtilExpectedLoggingTest.class );
+
+    @Override
+    ExpectedLogging expectedLoggingRule() {
+        return logging;
+    }
+
+    @Override
+    void logError( String message ) {
+        LOG.severe( message );
+    }
+
+    @Override
+    void logError( String message, Throwable detail ) {
+        LOG.log( Level.SEVERE, message, detail );
+    }
+
+    @Override
+    void logWarning( String message ) {
+        LOG.log( Level.WARNING, message );
+    }
+
+    @Override
+    void logWarning( String message, Throwable detail ) {
+        LOG.log( Level.WARNING, message, detail );
+    }
+
+    @Override
+    void logInfo( String message ) {
+        LOG.log( Level.INFO, message );
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,9 @@ project(':assertj-logging-logback') {
     }
 }
 
+project(':assertj-logging-jul') {
+}
+
 
 wrapper {
     gradleVersion = '7.3.3'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 rootProject.name = 'assertj-logging'
 
 include 'assertj-logging-core'
-include 'assertj-logging-log4j', 'assertj-logging-logback'
+include 'assertj-logging-log4j', 'assertj-logging-logback', 'assertj-logging-jul'


### PR DESCRIPTION
Refs #6

In  JavaUtilLoggingLogEventCaptureAppender#publish we could change the default case to silently ignore the LogRecord instead of throwing an Exception. This is a case that should not happen because assertj-logging only cares about log level info or higher, so an exception might be okay because it will point to something more serious.